### PR TITLE
fix: add missing includes

### DIFF
--- a/include/termui/core/style.hpp
+++ b/include/termui/core/style.hpp
@@ -3,7 +3,9 @@
 
 #include <map>
 #include <optional>
+#include <string>
 #include <termui/core/color.hpp>
+#include <vector>
 
 namespace termui {
 

--- a/include/termui/util.hpp
+++ b/include/termui/util.hpp
@@ -1,11 +1,13 @@
 #ifndef UTIL_HPP
 #define UTIL_HPP
 
+#include <cstdint>
 #include <format>
+#include <map>
 #include <string>
+#include <vector>
 
 namespace termui {
-
 std::string curs_up(int n);
 std::string curs_down(int n);
 std::string curs_right(int n);
@@ -27,10 +29,10 @@ inline std::string ENTER{10};
 inline std::string ESC{27};
 inline std::string DEL{127};
 
-inline std::string U_ARROW = "\e[A";
-inline std::string D_ARROW = "\e[B";
-inline std::string R_ARROW = "\e[C";
-inline std::string L_ARROW = "\e[D";
+inline std::string U_ARROW = "\x1b[A";
+inline std::string D_ARROW = "\x1b[B";
+inline std::string R_ARROW = "\x1b[C";
+inline std::string L_ARROW = "\x1b[D";
 
 inline std::string SHIFT_U_ARROW{27, 91, 49, 59, 50, 65}; // shift + arrow
 inline std::string SHIFT_D_ARROW{27, 91, 49, 59, 50, 66};
@@ -71,19 +73,19 @@ inline std::string DARK_SHADE = "▓";
 } // namespace unicode
 
 namespace term { /* random terminal manipulation codes */
-inline std::string CLEAR_CONSOLE = "\e[2J";
-inline std::string CLEAR_SCROLLBACK = "\e[3J";
-inline std::string CURSOR_HOME = "\e[H";
-inline std::string HIDE_CURSOR = "\e[?25l";
-inline std::string SHOW_CURSOR = "\e[?25h";
-inline std::string ALT_BUFFER = "\e[?1049h";     // enables the alternative buffer
-inline std::string PRIMARY_BUFFER = "\e[?1049l"; // disables the alternative buffer
+inline std::string CLEAR_CONSOLE = "\x1b[2J";
+inline std::string CLEAR_SCROLLBACK = "\x1b[3J";
+inline std::string CURSOR_HOME = "\x1b[H";
+inline std::string HIDE_CURSOR = "\x1b[?25l";
+inline std::string SHOW_CURSOR = "\x1b[?25h";
+inline std::string ALT_BUFFER = "\x1b[?1049h";     // enables the alternative buffer
+inline std::string PRIMARY_BUFFER = "\x1b[?1049l"; // disables the alternative buffer
 
-inline std::string SAVE_CURSOR = "\e7\e[s"; // uses dec and xterm code for compat
-inline std::string RESTORE_CURSOR = "\e8\e[u";
+inline std::string SAVE_CURSOR = "\0337\x1b[s"; // uses dec and xterm code for compat
+inline std::string RESTORE_CURSOR = "\0338\x1b[u";
 
-inline std::string ENABLE_MOUSE_REPORTING = "\e[?1003h\e[?1006h"; // using SGR, X10 is limited
-inline std::string DISABLE_MOUSE_REPORTING = "\e[?1003l\e[?1006l";
+inline std::string ENABLE_MOUSE_REPORTING = "\x1b[?1003h\x1b[?1006h"; // using SGR, X10 is limited
+inline std::string DISABLE_MOUSE_REPORTING = "\x1b[?1003l\x1b[?1006l";
 
 } // namespace term
 

--- a/src/system/mouse.cpp
+++ b/src/system/mouse.cpp
@@ -6,7 +6,7 @@ MouseInteraction::MouseInteraction(std::string s) : valid(true) {
   int  code, x, y;
   char mstate;
 
-  if (sscanf(s.data(), "\e[<%d;%d;%d%c", &code, &x, &y, &mstate) != 4) {
+  if (sscanf(s.data(), "\x1b[<%d;%d;%d%c", &code, &x, &y, &mstate) != 4) {
     valid = false;
     return;
   }

--- a/src/system/terminal.cpp
+++ b/src/system/terminal.cpp
@@ -80,32 +80,32 @@ uint Terminal::height() const {
 //   void SetOutputMode(OutputMode om);
 
 // --- Positioning ---
-void Terminal::MoveCursor(uint row, uint column) const { outbuff += std::format("\e[{};{}H", row, column); }
+void Terminal::MoveCursor(uint row, uint column) const { outbuff += std::format("\x1b[{};{}H", row, column); }
 //   void SaveCursorPosition();
 //   void RestoreCursorPosition();
 void Terminal::CursorUp(uint n) const {
   if (n == 0)
     return;
 
-  outbuff += std::format("\e[{}A", n);
+  outbuff += std::format("\x1b[{}A", n);
 }
 void Terminal::CursorDown(uint n) const {
   if (n == 0)
     return;
 
-  outbuff += std::format("\e[{}B", n);
+  outbuff += std::format("\x1b[{}B", n);
 }
 void Terminal::CursorForward(uint n) const {
   if (n == 0)
     return;
 
-  outbuff += std::format("\e[{}C", n);
+  outbuff += std::format("\x1b[{}C", n);
 }
 void Terminal::CursorBack(uint n) const {
   if (n == 0)
     return;
 
-  outbuff += std::format("\e[{}D", n);
+  outbuff += std::format("\x1b[{}D", n);
 }
 //   void CursorNextLine(uint n);
 //   void CursorPrevLine(uint n);
@@ -210,9 +210,9 @@ void TermSetup::configure() {
   (input_echoing == true) ? echo_on() : echo_off();
 
   // clang-format off
-  std::cout << ((show_cursor == true) ? "\e[?25h" : "\e[?25l") 
-            << ((alternate_output_buffer == true) ? "\e[?1049h" : "\e[?1049l")
-            << ((enable_mouse_reporting == true) ? "\e[?1003h\e[?1006h" : "\e[?1003l\e[?1006l") 
+  std::cout << ((show_cursor == true) ? "\x1b[?25h" : "\x1b[?25l") 
+            << ((alternate_output_buffer == true) ? "\x1b[?1049h" : "\x1b[?1049l")
+            << ((enable_mouse_reporting == true) ? "\x1b[?1003h\x1b[?1006h" : "\x1b[?1003l\x1b[?1006l") 
             << std::flush;
   // clang-format on
 }
@@ -235,9 +235,9 @@ void TermSetup::reset() { // sets terminal defaults, not blindly inversing confi
   io_buff_on();
   echo_on();
 
-  std::cout << "\e[?25h"            // show cursor
-            << "\e[?1049l"          // primary output buffer
-            << "\e[?1003l\e[?1006l" // mouse reporting off
+  std::cout << "\x1b[?25h"            // show cursor
+            << "\x1b[?1049l"          // primary output buffer
+            << "\x1b[?1003l\x1b[?1006l" // mouse reporting off
             << std::flush;
 }
 

--- a/src/ui/base/input.cpp
+++ b/src/ui/base/input.cpp
@@ -1,9 +1,12 @@
 #include <termui/ui/ui.hpp>
 
+#include <algorithm>
+#include <deque>
+
 namespace termui {
 
 Input::Input(const termui::string &value, const termui::string &placeholder, const Style &valStyle, const Style &plhStyle)
-  : _value(value), _placeholder(placeholder), _valStyle(valStyle), _plhStyle(plhStyle) {};
+  : _value(value), _placeholder(placeholder), _valStyle(valStyle), _plhStyle(plhStyle){};
 
 Input &Input::value(const termui::string &v) {
   _value = v;

--- a/src/ui/base/pager.cpp
+++ b/src/ui/base/pager.cpp
@@ -1,5 +1,7 @@
 #include <termui/ui/ui.hpp>
 
+#include <algorithm>
+
 namespace termui {
 
 Pager::Pager(const termui::string &str, const Style &style, uint width, uint height) : Text(str, style, width, height), _cursor(0) {}

--- a/src/ui/base/text.cpp
+++ b/src/ui/base/text.cpp
@@ -1,5 +1,7 @@
 #include <termui/ui/ui.hpp>
 
+#include <algorithm>
+
 namespace termui {
 
 Text::Text(const termui::string &str, const Style &style, uint width, uint height) : _text(str), _style(style), _w(width), _h(height) {}
@@ -29,18 +31,6 @@ Text &Text::size(uint w, uint h) {
   _h = h;
   return *this;
 }
-
-// Text &Text::cursor_up(uint count) {
-//   _cursor = (_cursor > 0) ? std::max(0, int(_cursor - count)) : 0; // decrement but dont let (cursor < 0)
-//   return *this;
-// }
-
-// Text &Text::cursor_down(uint count) {
-//   _cursor += count; // no checking is done here - the value is clamped in render() so that the bottom piece of text is always visible
-//   return *this;
-// }
-
-// uint Text::get_cursor() { return _cursor; }
 
 std::string Text::render() {
   if (_w == 0 || _h == 0) {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -3,10 +3,10 @@
 namespace termui {
 
 namespace ansi {
-std::string fg(uint8_t v) { return std::format("\e[38;5;{}m", v); };
-std::string fg(uint8_t r, uint8_t g, uint8_t b) { return std::format("\e[38;2;{};{};{}m", r, g, b); };
-std::string bg(uint8_t v) { return std::format("\e[48;5;{}m", v); };
-std::string bg(uint8_t r, uint8_t g, uint8_t b) { return std::format("\e[48;2;{};{};{}m", r, g, b); };
+std::string fg(uint8_t v) { return std::format("\x1b[38;5;{}m", v); };
+std::string fg(uint8_t r, uint8_t g, uint8_t b) { return std::format("\x1b[38;2;{};{};{}m", r, g, b); };
+std::string bg(uint8_t v) { return std::format("\x1b[48;5;{}m", v); };
+std::string bg(uint8_t r, uint8_t g, uint8_t b) { return std::format("\x1b[48;2;{};{};{}m", r, g, b); };
 } // namespace ansi
 
 std::string repeat(const std::string &s, int n) {
@@ -21,28 +21,28 @@ std::string curs_up(int n) {
   if (n == 0)
     return "";
 
-  return std::format("\e[{}A", n);
+  return std::format("\x1b[{}A", n);
 }
 
 std::string curs_down(int n) {
   if (n == 0)
     return "";
 
-  return std::format("\e[{}B", n);
+  return std::format("\x1b[{}B", n);
 }
 
 std::string curs_right(int n) {
   if (n == 0)
     return "";
 
-  return std::format("\e[{}C", n);
+  return std::format("\x1b[{}C", n);
 }
 
 std::string curs_left(int n) {
   if (n == 0)
     return "";
 
-  return std::format("\e[{}D", n);
+  return std::format("\x1b[{}D", n);
 }
 
 size_t visible_length(const std::string &s) {
@@ -53,7 +53,7 @@ size_t visible_length(const std::string &s) {
     unsigned char byte = static_cast<unsigned char>(s[index]);
 
     // CSI sequence: ESC [
-    if (byte == '\e' && index + 1 < s.size() && s[index + 1] == '[') {
+    if (byte == '\x1b' && index + 1 < s.size() && s[index + 1] == '[') {
 
       index += 2; // consume ESC [
 
@@ -96,7 +96,7 @@ size_t max_visible_length(const std::string &s, size_t n) {
     unsigned char byte = static_cast<unsigned char>(s[index]);
 
     // CSI sequence: ESC [
-    if (byte == '\e' && index + 1 < s.size() && s[index + 1] == '[') {
+    if (byte == '\x1b' && index + 1 < s.size() && s[index + 1] == '[') {
 
       index += 2; // consume ESC [
 
@@ -147,7 +147,7 @@ size_t reverse_max_visible_length(const std::string &s, size_t n) {
     unsigned char c = static_cast<unsigned char>(s[index]);
     ++index;
 
-    if (!in_csi && c == '\e' && index < s.size() && s[index] == '[') {
+    if (!in_csi && c == '\x1b' && index < s.size() && s[index] == '[') {
       in_csi = true;
       csi_start = index - 1;
 
@@ -217,7 +217,7 @@ std::string test_sgr_features() {
   std::string outbuff;
 
   for (int i = 0; i < 10; i++) {
-    outbuff += std::format("\e[{}mHello\e[0m\n", i);
+    outbuff += std::format("\x1b[{}mHello\x1b[0m\n", i);
   }
 
   return outbuff;


### PR DESCRIPTION
- adds missing includes for std::min with init list
- converts all \e to \033 or \e[ to \x1b[